### PR TITLE
feat: update seed and database reset scripts to use dotenv for environment variable management

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "build": "tsc && tsc-alias",
     "lint": "eslint . --ext .ts",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "seed": "ts-node -r tsconfig-paths/register prisma/seeds/index.seed.ts",
-    "seed:users": "ts-node -r tsconfig-paths/register prisma/seeds/users.seed.ts",
-    "seed:vehicles": "ts-node -r tsconfig-paths/register prisma/seeds/vehicles.seed.ts",
-    "seed:batteries": "ts-node -r tsconfig-paths/register prisma/seeds/batteries.seed.ts",
-    "db:reset": "npx prisma migrate reset --force && npm run seed"
+    "seed": "dotenv -e .env -- ts-node -r tsconfig-paths/register prisma/seeds/index.seed.ts",
+    "seed:staging": "dotenv -e .env.staging -- ts-node -r tsconfig-paths/register prisma/seeds/index.seed.ts",
+    "seed:users": "dotenv -e .env -- ts-node -r tsconfig-paths/register prisma/seeds/users.seed.ts",
+    "seed:vehicles": "dotenv -e .env -- ts-node -r tsconfig-paths/register prisma/seeds/vehicles.seed.ts",
+    "seed:batteries": "dotenv -e .env -- ts-node -r tsconfig-paths/register prisma/seeds/batteries.seed.ts",
+    "db:reset": "dotenv -e .env -- npx prisma migrate reset --force && npm run seed",
+    "db:reset:staging": "dotenv -e .env.staging -- npx prisma migrate reset --force && npm run seed:staging"
   },
   "keywords": [],
   "author": "DoQuangDung",


### PR DESCRIPTION
This pull request updates the database seeding and reset scripts in `package.json` to improve environment management and add support for staging. The most important changes are grouped below:

**Environment variable handling:**

* All seeding and database reset scripts now use the `dotenv` CLI to load environment variables from `.env` or `.env.staging`, ensuring the correct environment configuration is applied during these operations.

**Staging environment support:**

* Added new scripts `seed:staging` and `db:reset:staging` to allow database seeding and reset specifically for the staging environment, using `.env.staging`.