### PR TITLE
feat: include access token in Google OAuth callback response

### DIFF
--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -60,14 +60,16 @@ authRouter.get(
   }),
   (req, res) => {
     const user = req.user as any;
-    const { refreshToken } = generateTokens(user.id);
+    const { refreshToken, accessToken } = generateTokens(user.id);
     setTokenCookie(
       res,
       "refreshToken",
       refreshToken,
       "/api/v1/auth/refresh-token",
     );
-    return res.redirect(`${config.CLIENT_URL}/auth/success`);
+    return res.redirect(
+      `${config.CLIENT_URL}/auth/success?accessToken=${accessToken}`,
+    );
   },
 );
 


### PR DESCRIPTION
This pull request updates the authentication success redirect to include the access token as a URL query parameter. This allows the client application to receive the access token directly after authentication.

- Authentication flow update:
  * Modified the redirect in the `authRouter.get` handler in `src/routes/auth.route.ts` to append the generated `accessToken` as a query parameter to the success URL.