### PR TITLE
feat: update battery and vehicle image generation with predefined image sets

### DIFF
--- a/prisma/seeds/batteries.seed.ts
+++ b/prisma/seeds/batteries.seed.ts
@@ -23,17 +23,26 @@ const batteryBrands = [
   "Farasis Energy",
 ];
 
-const generateBatteryImages = (batteryIndex: number): string[] => {
+const batteryImages = [
+  "https://i.ebayimg.com/images/g/LRYAAOSwdWNke4Tb/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/jpYAAOSwci9lzry1/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/R8cAAeSw4zBox89t/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/ANoAAeSwEcVox8-5/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/O2YAAeSwYdJox9AH/s-l1600.webp",
+  "http://i.ebayimg.com/images/g/FK4AAOSwie5ntvct/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/qSAAAeSw-jFoeCjB/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/z3MAAeSwqgdooIXd/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/19sAAeSwsDVooIXg/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/v~IAAeSwQDponF99/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/z3MAAeSwqgdooIXd/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/e0EAAeSwHHFooIXf/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/UMUAAeSwEcJooxPJ/s-l1600.webp",
+  "https://i.ebayimg.com/images/g/3mUAAeSwgpJooxPM/s-l1600.webp",
+];
+
+const generateBatteryImages = (): string[] => {
   const imageCount = faker.number.int({ min: 2, max: 5 });
-  const images = [];
-
-  for (let i = 1; i <= imageCount; i++) {
-    images.push(
-      `https://placehold.co/600x400?text=battery_${batteryIndex}_${i}`,
-    );
-  }
-
-  return images;
+  return faker.helpers.arrayElements(batteryImages, imageCount);
 };
 
 const createBatteries = async (count: number = 15) => {
@@ -61,7 +70,7 @@ const createBatteries = async (count: number = 15) => {
       title: `${brand} ${capacity}kWh EV Battery Pack`,
       description: faker.lorem.paragraphs(2, "\n\n"),
       price: faker.number.float({ min: 8000, max: 50000, multipleOf: 500 }),
-      images: generateBatteryImages(i + 1),
+      images: generateBatteryImages(),
       status: faker.helpers.arrayElement([
         "AVAILABLE",
         "SOLD",

--- a/prisma/seeds/vehicles.seed.ts
+++ b/prisma/seeds/vehicles.seed.ts
@@ -25,17 +25,24 @@ const vehicleBrands = [
   "Polestar",
 ];
 
-const generateVehicleImages = (vehicleIndex: number): string[] => {
+const vehicleImages = [
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/2019_Tesla_Model_3_Performance_AWD_Front.jpg/1200px-2019_Tesla_Model_3_Performance_AWD_Front.jpg", // Tesla Model 3
+  "https://upload.wikimedia.org/wikipedia/commons/5/5c/Tesla_Model_Y_1X7A6211.jpg", // Tesla Model Y
+  "https://i1-vnexpress.vnecdn.net/2024/06/17/BYD-Atto-3-VNEXPRESS-27-JPG.jpg?w=2400&h=0&q=100&dpr=1&fit=crop&s=2BUkZZ_acW3duKCkNWNw8w&t=image", // BYD Atto 3
+  "https://upload.wikimedia.org/wikipedia/commons/d/de/Nissan_Leaf_2018_%2831874639158%29_%28cropped%29.jpg", // Nissan Leaf
+  "https://i1-vnexpress.vnecdn.net/2023/08/01/IMG-4443-JPG.jpg?w=2400&h=0&q=100&dpr=1&fit=crop&s=fYftX0XbAenDxjv3jPXEJg&t=image", // BMW i4
+  "https://upload.wikimedia.org/wikipedia/commons/d/d5/Audi_e-tron_GT_IMG_5689.jpg", // Audi e-tron GT
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Mercedes-Benz_V297_Classic-Days_2022_DSC_0016.jpg/1200px-Mercedes-Benz_V297_Classic-Days_2022_DSC_0016.jpg", // Mercedes-Benz EQS
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/8/85/Hyundai_Ioniq_5_AWD_Techniq-Paket_%E2%80%93_f_31122024.jpg/1200px-Hyundai_Ioniq_5_AWD_Techniq-Paket_%E2%80%93_f_31122024.jpg", // Hyundai Ioniq 5
+  "https://upload.wikimedia.org/wikipedia/commons/d/d9/2021_Kia_EV6_GT-Line_S.jpg", // Kia EV6
+  "https://upload.wikimedia.org/wikipedia/commons/4/49/2021_Ford_Mustang_Mach-E_Standard_Range_Front.jpg", // Ford Mustang Mach-E
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/2022_Rivian_R1T_%28in_Glacier_White%29%2C_front_6.21.22.jpg/1200px-2022_Rivian_R1T_%28in_Glacier_White%29%2C_front_6.21.22.jpg", // Rivian R1T
+  "https://hips.hearstapps.com/hmg-prod/images/2025-polestar-2-2-672d4eec1edeb.jpg?crop=0.732xw:0.617xh;0.130xw,0.302xh&resize=980:*", // Polestar 2
+];
+
+const generateVehicleImages = (): string[] => {
   const imageCount = faker.number.int({ min: 3, max: 5 });
-  const images = [];
-
-  for (let i = 1; i <= imageCount; i++) {
-    images.push(
-      `https://placehold.co/600x400?text=vehicle_${vehicleIndex}_${i}`,
-    );
-  }
-
-  return images;
+  return faker.helpers.arrayElements(vehicleImages, imageCount);
 };
 
 const createVehicles = async (count: number = 20) => {
@@ -63,7 +70,7 @@ const createVehicles = async (count: number = 20) => {
       title: `${year} ${brand} ${model}`,
       description: faker.lorem.paragraphs(2, "\n\n"),
       price: faker.number.float({ min: 15000, max: 150000, multipleOf: 500 }),
-      images: generateVehicleImages(i + 1),
+      images: generateVehicleImages(),
       status: faker.helpers.arrayElement([
         "AVAILABLE",
         "SOLD",


### PR DESCRIPTION
This pull request updates the seed data for batteries and vehicles to use a curated set of realistic image URLs instead of placeholder images. The image selection logic is also simplified to randomly pick from these real images, improving the quality and realism of the seeded data.

**Seed Data Improvements:**

* Replaced the placeholder image generation in `batteries.seed.ts` with a curated array of real battery image URLs, and updated the `generateBatteryImages` function to randomly select a subset for each battery.
* Updated the battery creation logic to use the new `generateBatteryImages` function, removing the dependency on the battery index.
* Replaced the placeholder image generation in `vehicles.seed.ts` with a curated array of real vehicle image URLs, and updated the `generateVehicleImages` function to randomly select a subset for each vehicle.
* Updated the vehicle creation logic to use the new `generateVehicleImages` function, removing the dependency on the vehicle index.