### PR TITLE
fix: update redirect URL for deposit request to point to the wallet homepage

### DIFF
--- a/src/services/wallet.service.ts
+++ b/src/services/wallet.service.ts
@@ -58,7 +58,7 @@ export const walletService = {
       },
     });
 
-    const redirectUrl = `${config.CLIENT_URL}/wallet/deposit/result`;
+    const redirectUrl = `${config.CLIENT_URL}/wallet/`;
     const ipnUrl = `${config.NGROK_URL}/api/v1/payments/momo/ipn`; // URL webhook của bạn
 
     const paymentInfo = await momoService.createPayment({


### PR DESCRIPTION
This pull request makes a small update to the wallet service by changing the redirect URL after a deposit is made. The new redirect URL now points to the main wallet page instead of the deposit result page.