### PR TITLE
fix: update IPN URL to use environment-specific configuration

### DIFF
--- a/src/services/wallet.service.ts
+++ b/src/services/wallet.service.ts
@@ -59,7 +59,7 @@ export const walletService = {
     });
 
     const redirectUrl = `${config.CLIENT_URL}/wallet/`;
-    const ipnUrl = `${config.NGROK_URL}/api/v1/payments/momo/ipn`; // URL webhook của bạn
+    const ipnUrl = `${config.NODE_ENV === "production" ? config.CLIENT_URL : config.NGROK_URL}/api/v1/payments/momo/ipn`; // URL webhook của bạn
 
     const paymentInfo = await momoService.createPayment({
       orderId: financialTransaction.id,


### PR DESCRIPTION
This pull request updates the logic for generating the IPN (Instant Payment Notification) URL in the `walletService`. The change ensures that the correct webhook URL is used depending on whether the application is running in production or development mode.

* Payment integration: The `ipnUrl` in `walletService` is now set to use `config.CLIENT_URL` in production and `config.NGROK_URL` otherwise, ensuring the appropriate webhook endpoint is used for Momo payments.