### PR TITLE
fix: update IPN URL to use SERVER_URL instead of NGROK_URL

### DIFF
--- a/src/configs/env.config.ts
+++ b/src/configs/env.config.ts
@@ -17,7 +17,7 @@ const config = {
   NODE_ENV: process.env.NODE_ENV,
   CLIENT_URL: process.env.CLIENT_URL,
   DIRECT_URL: process.env.DIRECT_URL,
-  NGROK_URL: process.env.NGROK_URL,
+  SERVER_URL: process.env.SERVER_URL,
   WHITELIST_ORIGINS: (process.env.CORS_ALLOWED_ORIGINS || "")
     .split(",")
     .filter(Boolean),

--- a/src/services/wallet.service.ts
+++ b/src/services/wallet.service.ts
@@ -59,7 +59,7 @@ export const walletService = {
     });
 
     const redirectUrl = `${config.CLIENT_URL}/wallet/`;
-    const ipnUrl = `${config.NODE_ENV === "production" ? config.CLIENT_URL : config.NGROK_URL}/api/v1/payments/momo/ipn`; // URL webhook của bạn
+    const ipnUrl = `${config.SERVER_URL}/payments/momo/ipn`; // URL webhook của bạn
 
     const paymentInfo = await momoService.createPayment({
       orderId: financialTransaction.id,


### PR DESCRIPTION
This pull request updates environment variable usage and refactors the payment webhook URL configuration to improve clarity and maintainability. The most important changes are grouped below:

**Configuration Updates:**

* Replaced the `NGROK_URL` environment variable with `SERVER_URL` in `env.config.ts`, updating the configuration to use a more generic and descriptive server URL.

**Payment Service Refactor:**

* Changed the construction of the MoMo payment webhook (`ipnUrl`) in `wallet.service.ts` to always use `SERVER_URL` instead of switching between `CLIENT_URL` and `NGROK_URL` based on environment, simplifying the logic and ensuring consistency.