### PR TITLE
fix: ensure wallet is created upon user registration

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -178,6 +178,9 @@ export const authService = {
           },
         },
       });
+
+      await walletService.createWallet(user.id);
+
       return user;
     }
     await prisma.account.create({


### PR DESCRIPTION
This pull request introduces a new step to the user registration flow by ensuring a wallet is created for each new user. The wallet creation is now triggered immediately after a user is registered.

User registration improvements:

* Added a call to `walletService.createWallet` after creating a new user in `authService`, ensuring every new user gets an associated wallet.