### PR TITLE
fix: Update vehicle transaction handling to include sale type condition

### DIFF
--- a/src/services/checkout.service.ts
+++ b/src/services/checkout.service.ts
@@ -336,7 +336,10 @@ export const checkoutService = {
         await walletService.addLockedBalance(listing.sellerId, price, tx);
 
         // Nếu là giao dịch đặt cọc xe
-        if (transaction.listingType === "VEHICLE") {
+        if (
+          transaction.listingType === "VEHICLE" &&
+          transaction.type === "SALE"
+        ) {
           const appointmentDeadline = new Date();
           appointmentDeadline.setDate(appointmentDeadline.getDate() + 7);
 


### PR DESCRIPTION
This pull request makes a targeted update to the logic for handling vehicle deposit transactions in the `checkoutService`. The change ensures that the appointment deadline is only set for transactions that are both related to vehicles and are of the type "SALE".

- Improved transaction filtering:
  * In `checkout.service.ts`, updated the condition to set the appointment deadline so that it only applies when `transaction.listingType` is `"VEHICLE"` and `transaction.type` is `"SALE"`. This prevents appointment deadlines from being set for vehicle transactions that are not sales.