### PR TITLE
fix: Add listingType and type fields to admin and appointment services

### DIFF
--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -582,6 +582,8 @@ export const adminService = {
             select: {
               id: true,
               status: true,
+              listingType: true,
+              type: true,
               vehicle: { select: { id: true, title: true, images: true } },
             },
           },

--- a/src/services/appointment.service.ts
+++ b/src/services/appointment.service.ts
@@ -131,6 +131,8 @@ export const appointmentService = {
             select: {
               id: true,
               status: true,
+              listingType: true,
+              type: true,
               vehicle: { select: { title: true, images: true } },
             },
           },


### PR DESCRIPTION
This pull request adds more detailed information to the data returned by both the `adminService` and `appointmentService`. Specifically, it now includes the `listingType` and `type` fields in the selected appointment data, which will provide additional context for each appointment.

The most important changes are:

**Appointment and Admin Service Data Enhancements:**

* In `src/services/appointment.service.ts`, the appointment selection now includes the `listingType` and `type` fields, in addition to existing fields.
* In `src/services/admin.service.ts`, the admin selection also now includes the `listingType` and `type` fields.