### PR TITLE
fix: Update confirmation logic to allow transactions in SHIPPED or APPOINTMENT_SCHEDULED status

### DIFF
--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -129,9 +129,10 @@ export const transactionService = {
     if (transaction.buyerId !== buyerId) {
       throw new ForbiddenError("You are not the buyer of this transaction.");
     }
-    if (transaction.status !== "SHIPPED") {
+    const allowedStatuses: string[] = ["SHIPPED", "APPOINTMENT_SCHEDULED"];
+    if (!allowedStatuses.includes(transaction.status)) {
       throw new BadRequestError(
-        "Transaction must be in SHIPPED status to be confirmed.",
+        "Transaction must be in SHIPPED or APPOINTMENT_SCHEDULED status to be confirmed.",
       );
     }
 


### PR DESCRIPTION
This pull request updates the transaction confirmation logic to allow transactions in both the "SHIPPED" and "APPOINTMENT_SCHEDULED" statuses to be confirmed, instead of only "SHIPPED".

- Transaction confirmation logic now permits confirmation when the transaction status is either "SHIPPED" or "APPOINTMENT_SCHEDULED", and updates the error message accordingly. (`src/services/transaction.service.ts`)