### PR TITLE
fix: Update completeTransaction to set finalPrice when marking as completed

### DIFF
--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -442,7 +442,10 @@ export const transactionService = {
 
       return tx.transaction.update({
         where: { id: transactionId },
-        data: { status: "COMPLETED" }, // Chuyển thẳng sang COMPLETED
+        data: {
+          status: "COMPLETED",
+          finalPrice: totalVehiclePrice, // Cập nhật giá cuối cùng thành 100%
+        },
       });
     });
   },


### PR DESCRIPTION
This pull request makes a minor update to the `transactionService` in `transaction.service.ts`, ensuring that when a transaction is marked as "COMPLETED", the `finalPrice` is also updated to reflect the total vehicle price.

- When updating a transaction's status to "COMPLETED", the `finalPrice` field is now set to `totalVehiclePrice` to ensure the final price is correctly recorded.